### PR TITLE
docs: align badges to the right

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -49,7 +49,7 @@ If you have requirements for JavaScript tools at scale, please [get in touch](ht
 Major projects in this organization:
 
 | Project | Description | Link |
-| ------- | ----------- | ---- |
+| ------- | ----------- | ----:|
 | [oxlint](https://github.com/oxc-project/oxc) | ESLint-compatible linter | [![NPM Downloads](https://img.shields.io/npm/dw/oxlint?label=oxlint)](https://npmx.dev/package/oxlint) |
 | [oxfmt](https://github.com/oxc-project/oxc) | Prettier-compatible formatter | [![NPM Downloads](https://img.shields.io/npm/dw/oxfmt?label=oxfmt)](https://npmx.dev/package/oxfmt) |
 | [tsgolint](https://github.com/oxc-project/tsgolint) | Type-aware linting for oxlint | [![NPM Downloads](https://img.shields.io/npm/dw/oxlint-tsgolint?label=oxlint-tsgolint)](https://npmx.dev/package/oxlint-tsgolint) |


### PR DESCRIPTION
<img width="995" height="965" alt="grafik" src="https://github.com/user-attachments/assets/7f4dab3b-51c8-4c54-8553-a7fe0268210a" />

Looks nicer for my eye when `/week` is aligned on the right, The badge names are different length, so it is hard to compare the weekly downloads for each package