### PR TITLE
chore: normalize funding metadata

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,1 @@
-github: [Boshen]
 open_collective: oxc
-thanks_dev: u/gh/oxc-project


### PR DESCRIPTION
Remove personal sponsorship targets from selected funding files and direct sponsorship to the Oxc Open Collective only.